### PR TITLE
Fix issues with publicUrl, windows paths and deeply nested files

### DIFF
--- a/src/BundleManifestReporter.ts
+++ b/src/BundleManifestReporter.ts
@@ -1,40 +1,52 @@
-import { Reporter } from '@parcel/plugin'
-import path from 'path'
+import { Reporter } from '@parcel/plugin';
+import path from 'path';
+
+const normalisePath = (p: string) => {
+  return p.replace(/[\\/]+/g, '/');
+};
 
 export default new Reporter({
-  async report({ event, options }: any) { // TODO: Add type definition for Reporter
+  async report({ event, options }: any) {
+    // TODO: Add type definition for Reporter
     if (event.type !== 'buildSuccess') {
-      return
+      return;
     }
 
-    let bundlesByTarget = new Map()
+    let bundlesByTarget = new Map();
 
     for (let bundle of event.bundleGraph.getBundles()) {
       if (!bundle.isInline) {
-        let bundles = bundlesByTarget.get(bundle.target.distDir)
+        let bundles = bundlesByTarget.get(bundle.target.distDir);
 
         if (!bundles) {
-          bundles = []
-          bundlesByTarget.set(bundle.target.distDir, bundles)
+          bundles = [];
+          bundlesByTarget.set(bundle.target.distDir, bundles);
         }
 
-        bundles.push(bundle)
+        bundles.push(bundle);
       }
     }
 
     for (let [targetDir, bundles] of bundlesByTarget) {
-      let manifest: Manifest = {}
+      let manifest: Manifest = {};
 
       for (let bundle of bundles) {
-        const assetPath = bundle.getMainEntry().filePath
-        const assetName = path.basename(assetPath)
-        manifest[assetName] = '/' + bundle.name
+        const mainEntry = bundle.getMainEntry();
+        if (mainEntry) {
+          const assetPath = mainEntry.filePath;
+          const assetName = normalisePath(path.relative(options.rootDir, assetPath));
+          const bundleUrl = normalisePath(`${bundle.target.publicUrl}/${bundle.name}`);
+
+          manifest[assetName] = bundleUrl;
+        }
       }
 
-      await options.outputFS.writeFile(`${targetDir}/${MANIFEST_FILENAME}`, JSON.stringify(manifest))
+      const targetPath = `${targetDir}/${MANIFEST_FILENAME}`;
+      await options.outputFS.writeFile(targetPath, JSON.stringify(manifest));
+      console.log(`📄 Wrote bundle manifest to: ${targetPath}`);
     }
-  }
-})
+  },
+});
 
-export type Manifest = { [assetName: string]: string }
-export const MANIFEST_FILENAME = 'parcel-manifest.json'
+export type Manifest = { [assetName: string]: string };
+export const MANIFEST_FILENAME = 'parcel-manifest.json';


### PR DESCRIPTION
This PR improves handling of windows paths, entrypoints that are not in the rootDir and prefixes target paths with publicUrl like the original plugin 