### PR TITLE
Include bundle that doesn't have an entrypoint in the manifest

### DIFF
--- a/src/BundleManifestReporter.ts
+++ b/src/BundleManifestReporter.ts
@@ -31,9 +31,19 @@ export default new Reporter({
       let manifest: Manifest = {}
 
       for (let bundle of bundles) {
-        const mainEntry = bundle.getMainEntry()
-        if (mainEntry) {
-          const assetPath = mainEntry.filePath
+        /**
+         * Only use the first asset of the bundle as the key of the manifest.
+         * 
+         * Some bundle doesn't have a main entry (`bundle.getMainEntry()`); e.g. CSS bundle that's the result of CSS files imported from JS.
+         * 
+         * The bundle could have multiple assets; e.g. multiple CSS files combined into one bundle,
+         * so we only choose the first one to avoid multiple bundle in the manifest.
+         * 
+         * We cannot use the bundled file name without hash as a key because there' might be only hash; e.g. styles.css -> asdfjkl.css.
+         */
+        const asset = bundle.getEntryAssets()[0]
+        if (asset) {
+          const assetPath = asset.filePath
           const assetName = normalisePath(
             // Fallback to rootDir for the current beta version
             // https://github.com/parcel-bundler/parcel/pull/4896 change to entryRoot in the current nightly version

--- a/tests/BundleManifestReporter.test.ts
+++ b/tests/BundleManifestReporter.test.ts
@@ -19,6 +19,11 @@ test("parcel-nightly", async () => {
   await buildAndAssertManifestFile()
 })
 
+test("js-import-css", async () => {
+  process.chdir(path.join(__dirname, "./fixtures/js-import-css"))
+  await buildAndAssertManifestFile()
+})
+
 async function buildAndAssertManifestFile() {
   execSync(
     "rm -rf package-lock.json .parcel-cache dist node_modules && npm install && npm run build"

--- a/tests/fixtures/js-import-css/.parcelrc
+++ b/tests/fixtures/js-import-css/.parcelrc
@@ -1,0 +1,4 @@
+{
+  "extends": "@parcel/config-default",
+  "reporters": ["...", "parcel-reporter-bundle-manifest"]
+}

--- a/tests/fixtures/js-import-css/package.json
+++ b/tests/fixtures/js-import-css/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "js-import-css",
+  "private": true,
+  "scripts": {
+    "build": "parcel build src/index.html"
+  },
+  "devDependencies": {
+    "parcel": "2.0.0-nightly.438",
+    "parcel-reporter-bundle-manifest": "file:../../.."
+  }
+}

--- a/tests/fixtures/js-import-css/src/index.html
+++ b/tests/fixtures/js-import-css/src/index.html
@@ -1,0 +1,3 @@
+<html>
+  <script src="./script.js"></script>
+</html>

--- a/tests/fixtures/js-import-css/src/script.js
+++ b/tests/fixtures/js-import-css/src/script.js
@@ -1,0 +1,4 @@
+import "./styles1.css"
+import "./styles2.css"
+
+console.log("1")

--- a/tests/fixtures/js-import-css/src/styles1.css
+++ b/tests/fixtures/js-import-css/src/styles1.css
@@ -1,0 +1,3 @@
+body {
+  background: gray;
+}

--- a/tests/fixtures/js-import-css/src/styles2.css
+++ b/tests/fixtures/js-import-css/src/styles2.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}


### PR DESCRIPTION
Fixes #101 

Before | After
--- | ---
<img width="876" alt="Screen Shot 2020-11-09 at 4 39 50" src="https://user-images.githubusercontent.com/7040242/98482572-af0ec280-2245-11eb-9ce3-8314d15e0c3f.png"> | <img width="863" alt="Screen Shot 2020-11-09 at 4 30 17" src="https://user-images.githubusercontent.com/7040242/98482573-b1711c80-2245-11eb-8cba-e33727482833.png">
